### PR TITLE
Added mp4, mp3, webm, and m4a mimetypes to build.gradle to accept

### DIFF
--- a/book/build.gradle
+++ b/book/build.gradle
@@ -159,7 +159,11 @@ task epub_resources(
     "jpeg": "image/jpeg",
     "png": "image/png",
     "gif": "image/gif",
-    "svg": "image/svg"
+    "svg": "image/svg",
+    "mp4": "video/mp4",
+    "webm": "video/webm",
+    "mp3": "audio/mp3",
+    "m4a": "audio/m4a"
   ]
 
   doLast {


### PR DESCRIPTION
minimal audio/video mimetypes for the epub transform